### PR TITLE
Mentioned dedicated IPs for scenario 2 of email configuration

### DIFF
--- a/pages/prerequisites/CKLS.md
+++ b/pages/prerequisites/CKLS.md
@@ -273,12 +273,13 @@ REPLYTO:john.doe@client.com
 </pre>
 </td></tr>
 <tr>
-<td>All emails are sent by Amazon SES service using a FROM adresse that belongs to the client's domain (or crossknowledge.com domain)
+<td>All emails are sent by Amazon SES service using a FROM adress that belongs to the client's domain (or crossknowledge.com domain)
 </td>
 <td>
 <p>This setup requires some extra IT configuration tasks for both CrossKnowledge and client's IT Teams&nbsp;: DKIM entries to be added in client's DNS zone&nbsp;: client.com. <br>
 E.g mail can be sent from noreply@client.com or any other @client.com addresses. <br>
 In case an email having a FROM attribute not belonging to either client.com or crossknowledge.com domain, the FROM attribute is automatically replaced by noreply@client.com or any other generic address chosen by the client during the setup phase.
+Dedicated IPs can be used for whitelisting or security purposes.
 </p>
 </td></tr>
 <tr>


### PR DESCRIPTION
The IT Team has added the possibility to use dedicated IPs for email sending via AWS SES.
A few clients are already using them (Legrand, MyLearning...) and this can help for the setup of other clients.
